### PR TITLE
Upgrade Compose Compiler to 1.4.0-alpha02

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,8 +79,8 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
-    implementation "com.google.accompanist:accompanist-pager:0.28.0"
-    implementation "com.google.accompanist:accompanist-pager-indicators:0.28.0"
+    implementation "com.google.accompanist:accompanist-pager:0.29.0-alpha"
+    implementation "com.google.accompanist:accompanist-pager-indicators:0.29.0-alpha"
 
     implementation 'io.coil-kt:coil-compose:2.2.2'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation 'androidx.compose.material3:material3'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
     debugImplementation "androidx.compose.ui:ui-tooling"
     debugImplementation "androidx.compose.ui:ui-test-manifest"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.4.0-alpha02'
     }
     packagingOptions {
         resources {
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2022.12.00')
+    implementation platform('androidx.compose:compose-bom:2023.01.00')
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation 'androidx.compose.material3:material3'

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0-rc03' apply false
-    id 'com.android.library' version '7.4.0-rc03' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.library' version '7.4.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
     id 'com.vanniktech.maven.publish' version '0.23.1'
 }

--- a/zoomable/build.gradle
+++ b/zoomable/build.gradle
@@ -58,9 +58,6 @@ dependencies {
     implementation "androidx.compose.foundation:foundation"
     implementation "androidx.compose.ui:ui-util"
 
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/zoomable/build.gradle
+++ b/zoomable/build.gradle
@@ -49,12 +49,12 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.4.0-alpha02'
     }
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2022.12.00')
+    implementation platform('androidx.compose:compose-bom:2023.01.00')
     implementation "androidx.compose.foundation:foundation"
     implementation "androidx.compose.ui:ui-util"
 


### PR DESCRIPTION
- Compose Compiler 1.4.0-alpha02
- Compose BOM 2023.01.00
- Kotlin 1.7.21
- AGP 7.4.0