### PR TITLE
Revert Compose to 1.3.2 and specify dependencies individually

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,12 +63,11 @@ android {
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2023.01.00')
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.ui:ui-tooling-preview"
-    implementation 'androidx.compose.material3:material3'
-    debugImplementation "androidx.compose.ui:ui-tooling"
-    debugImplementation "androidx.compose.ui:ui-test-manifest"
+    implementation "androidx.compose.ui:ui:1.3.3"
+    implementation "androidx.compose.ui:ui-tooling-preview:1.3.3"
+    implementation 'androidx.compose.material3:material3:1.0.1'
+    debugImplementation "androidx.compose.ui:ui-tooling:1.3.3"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:1.3.3"
 
     implementation project(path: ':zoomable')
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion '1.3.2'
     }
     packagingOptions {
         resources {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,6 @@ buildscript {
 plugins {
     id 'com.android.application' version '7.4.0' apply false
     id 'com.android.library' version '7.4.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'com.vanniktech.maven.publish' version '0.23.1'
 }

--- a/zoomable/build.gradle
+++ b/zoomable/build.gradle
@@ -54,9 +54,11 @@ android {
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2023.01.00')
-    implementation "androidx.compose.foundation:foundation"
-    implementation "androidx.compose.ui:ui-util"
+    implementation "androidx.compose.animation:animation-core:1.3.3"
+    implementation "androidx.compose.foundation:foundation:1.3.1"
+    implementation "androidx.compose.runtime:runtime:1.3.3"
+    implementation "androidx.compose.ui:ui:1.3.3"
+    implementation "androidx.compose.ui:ui-util:1.3.3"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'

--- a/zoomable/build.gradle
+++ b/zoomable/build.gradle
@@ -49,7 +49,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion '1.3.2'
     }
 }
 


### PR DESCRIPTION
Revert Compose compiler version to 1.3.2 and Kotlin to 1.7.20.

And specify dependent library versions individually instead of using Compose BOM.
Because we are going to support unstable version of compose libraries in the future.