### PR TITLE
Fix instrument tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew zoomable:testDebugUnitTest
 
   instrument_tests:
-    runs-on: macOS-10.15
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Use macOS-latest.
Because macOS-10.15 is now not recommended.