### PR TITLE
Support double tap zoom

### DIFF
--- a/zoomable/src/androidTest/java/net/engawapg/lib/zoomable/ZoomableTest.kt
+++ b/zoomable/src/androidTest/java/net/engawapg/lib/zoomable/ZoomableTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performTouchInput
@@ -77,4 +78,82 @@ class ZoomableTest {
         println("bounds=$boundsAfter")
         assert(boundsAfter.width > boundsBefore.width && boundsAfter.height > boundsBefore.height)
     }
+
+    @Test
+    fun zoomable_doubleTapZoomScale_zoomed() {
+        composeTestRule.setContent {
+            val painter = painterResource(id = android.R.drawable.ic_dialog_info)
+            val zoomState = rememberZoomState(contentSize = painter.intrinsicSize)
+            Image(
+                painter = painter,
+                contentDescription = "image",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zoomable(
+                        zoomState = zoomState,
+                        doubleTapZoomSpec = DoubleTapZoomScale(2f),
+                    )
+            )
+        }
+
+        val node = composeTestRule.onNodeWithContentDescription("image")
+        val bounds0 = node.fetchSemanticsNode().boundsInRoot
+
+        node.performTouchInput {
+            doubleClick(center)
+        }
+        val bounds1 = node.fetchSemanticsNode().boundsInRoot
+        assert((bounds1.width / bounds0.width) == 2f)
+        assert((bounds1.height / bounds0.height) == 2f)
+
+        node.performTouchInput {
+            doubleClick(center)
+        }
+        val bounds2 = node.fetchSemanticsNode().boundsInRoot
+        assert(bounds2.size == bounds0.size)
+    }
+
+    @Test
+    fun zoomable_doubleTapZoomScaleList_zoomed() {
+        composeTestRule.setContent {
+            val painter = painterResource(id = android.R.drawable.ic_dialog_info)
+            val zoomState = rememberZoomState(contentSize = painter.intrinsicSize)
+            Image(
+                painter = painter,
+                contentDescription = "image",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zoomable(
+                        zoomState = zoomState,
+                        doubleTapZoomSpec = DoubleTapZoomScaleList(listOf(1f, 2f, 3f))
+                    )
+            )
+        }
+
+        val node = composeTestRule.onNodeWithContentDescription("image")
+        val bounds0 = node.fetchSemanticsNode().boundsInRoot
+
+        node.performTouchInput {
+            doubleClick(center)
+        }
+        val bounds1 = node.fetchSemanticsNode().boundsInRoot
+        assert((bounds1.width / bounds0.width) == 2f)
+        assert((bounds1.height / bounds0.height) == 2f)
+
+        node.performTouchInput {
+            doubleClick(center)
+        }
+        val bounds2 = node.fetchSemanticsNode().boundsInRoot
+        assert((bounds2.width / bounds0.width) == 3f)
+        assert((bounds2.height / bounds0.height) == 3f)
+
+        node.performTouchInput {
+            doubleClick(center)
+        }
+        val bounds3 = node.fetchSemanticsNode().boundsInRoot
+        assert(bounds3.size == bounds0.size)
+    }
+
 }

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/DoubleTapZoomSpec.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/DoubleTapZoomSpec.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 usuiat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.engawapg.lib.zoomable
+
+/**
+ * [DoubleTapZoomSpec] defines a specification of zooming when double tap is detected.
+ */
+interface DoubleTapZoomSpec {
+
+    /**
+     * Determines the next scale value from the current scale value.
+     *
+     * The [ZoomState] object will call this function and pass the current scale value to
+     * [currentScale] when a double tap gesture is detected.
+     *
+     * @param currentScale The current scale value.
+     * @return The next scale value. The [ZoomState] object will change the scale to this value.
+     */
+    fun nextScale(currentScale: Float): Float
+
+    companion object {
+        /**
+         * Disable double tap gesture.
+         */
+        val Disable: DoubleTapZoomSpec = object : DoubleTapZoomSpec {
+            override fun nextScale(currentScale: Float) = currentScale
+        }
+    }
+}
+
+/**
+ * Toggle the scale between 1.0 and [zoomScale] every time when double tap gesture is detected.
+ *
+ * When double tap gesture is detected,
+ * - if the scale is 1.0, the scale will change to the [zoomScale].
+ * - if the scale is not 1.0, the scale will change to 1.0.
+ *
+ * @param zoomScale The zoom scale value after double tap gesture is detected.
+ */
+class DoubleTapZoomScale(private val zoomScale: Float): DoubleTapZoomSpec {
+    override fun nextScale(currentScale: Float): Float {
+        return if (currentScale == 1f) zoomScale else 1f
+    }
+}
+
+/**
+ * Adopt the scale defined in the [scaleList] every time when double tap gesture is detected.
+ *
+ * @param scaleList The zoom scale values. The values must be defined in order of ascending.
+ */
+class DoubleTapZoomScaleList(private val scaleList: List<Float>): DoubleTapZoomSpec {
+    override fun nextScale(currentScale: Float): Float {
+        if (scaleList.isEmpty()) {
+            return currentScale
+        }
+
+        for (scale in scaleList) {
+            if (currentScale < scale) {
+                return scale
+            }
+        }
+
+        return scaleList[0]
+    }
+}

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
@@ -247,12 +247,12 @@ class ZoomState(
         // Position with the origin at the left top corner of the content.
         val xInContent = position.x - offsetX + (size.width - layoutSize.width) * 0.5f
         val yInContent = position.y - offsetY + (size.height - layoutSize.height) * 0.5f
-        // Offset to zoom the content around the pinch gesture position.
-        val newOffsetX = (deltaWidth * 0.5f) - (deltaWidth * xInContent / size.width)
-        val newOffsetY = (deltaHeight * 0.5f) - (deltaHeight * yInContent / size.height)
+        // Amount of offset change required to zoom around the position.
+        val deltaX = (deltaWidth * 0.5f) - (deltaWidth * xInContent / size.width)
+        val deltaY = (deltaHeight * 0.5f) - (deltaHeight * yInContent / size.height)
 
-        val x = offsetX + pan.x + newOffsetX
-        val y = offsetY + pan.y + newOffsetY
+        val x = offsetX + pan.x + deltaX
+        val y = offsetY + pan.y + deltaY
 
         return Offset(x, y)
     }

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
@@ -209,7 +209,7 @@ class ZoomState(
         targetScale: Float,
         position: Offset,
     ) = coroutineScope {
-        val newScale = targetScale.coerceIn(0.9f, maxScale)
+        val newScale = targetScale.coerceIn(1f, maxScale)
         val newOffset = calculateNewOffset(newScale, position, Offset.Zero)
         val newBounds = calculateNewBounds(newScale)
 

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
@@ -233,15 +233,19 @@ class ZoomState(
         val newOffsetY = (deltaHeight * 0.5f) - (deltaHeight * yInContent / size.height)
 
         val boundX = max((newSize.width - layoutSize.width), 0f) * 0.5f
-        _offsetX.updateBounds(-boundX, boundX)
+        val x = (offsetX + newOffsetX).coerceIn(-boundX, boundX)
         launch {
-            _offsetX.animateTo(offsetX + newOffsetX)
+            _offsetX.updateBounds(null, null)
+            _offsetX.animateTo(x)
+            _offsetX.updateBounds(-boundX, boundX)
         }
 
         val boundY = max((newSize.height - layoutSize.height), 0f) * 0.5f
-        _offsetY.updateBounds(-boundY, boundY)
+        val y = (offsetY + newOffsetY).coerceIn(-boundY, boundY)
         launch {
-            _offsetY.animateTo(offsetY + newOffsetY)
+            _offsetY.updateBounds(null, null)
+            _offsetY.animateTo(y)
+            _offsetY.updateBounds(-boundY, boundY)
         }
 
         launch {

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
@@ -18,8 +18,10 @@ package net.engawapg.lib.zoomable
 
 import androidx.annotation.FloatRange
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -208,6 +210,7 @@ class ZoomState(
     internal suspend fun changeScale(
         targetScale: Float,
         position: Offset,
+        animationSpec: AnimationSpec<Float> = spring(),
     ) = coroutineScope {
         val newScale = targetScale.coerceIn(1f, maxScale)
         val newOffset = calculateNewOffset(newScale, position, Offset.Zero)
@@ -216,19 +219,19 @@ class ZoomState(
         val x = newOffset.x.coerceIn(newBounds.left, newBounds.right)
         launch {
             _offsetX.updateBounds(null, null)
-            _offsetX.animateTo(x)
+            _offsetX.animateTo(x, animationSpec)
             _offsetX.updateBounds(newBounds.left, newBounds.right)
         }
 
         val y = newOffset.y.coerceIn(newBounds.top, newBounds.bottom)
         launch {
             _offsetY.updateBounds(null, null)
-            _offsetY.animateTo(y)
+            _offsetY.animateTo(y, animationSpec)
             _offsetY.updateBounds(newBounds.top, newBounds.bottom)
         }
 
         launch {
-            _scale.animateTo(newScale)
+            _scale.animateTo(newScale, animationSpec)
         }
 
         shouldFling = false

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -210,6 +210,7 @@ private class TouchSlop(private val threshold: Float) {
 fun Modifier.zoomable(
     zoomState: ZoomState,
     enableOneFingerZoom: Boolean = true,
+    doubleTapZoomSpec: DoubleTapZoomSpec = DoubleTapZoomScale(2.5f)
 ): Modifier = composed(
     inspectorInfo = debugInspectorInfo {
         name = "zoomable"
@@ -245,7 +246,7 @@ fun Modifier.zoomable(
                 },
                 onDoubleTap = { position ->
                     scope.launch {
-                        val scale = if (zoomState.scale == 1f) 2f else 1f
+                        val scale = doubleTapZoomSpec.nextScale(zoomState.scale)
                         zoomState.changeScale(scale, position)
                     }
                 },

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -48,6 +48,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
     onGesture: (centroid: Offset, pan: Offset, zoom: Float, timeMillis: Long) -> Boolean,
     onGestureStart: () -> Unit = {},
     onGestureEnd: () -> Unit = {},
+    onDoubleTap: (position: Offset) -> Unit = {},
     enableOneFingerZoom: Boolean = true,
 ) = awaitEachGesture {
     val firstDown = awaitFirstDown(requireUnconsumed = false)
@@ -82,7 +83,10 @@ private suspend fun PointerInputScope.detectTransformGestures(
 
     // Vertical scrolling following a double tap is treated as a zoom gesture.
     if (enableOneFingerZoom && isTap) {
-        if (awaitSecondDown(firstUp) != null) {
+        val secondDown = awaitSecondDown(firstUp)
+        if (secondDown != null) {
+            var isDoubleTap = true
+            var secondUp: PointerInputChange = secondDown
             val secondTouchSlop = TouchSlop(viewConfiguration.touchSlop)
             forEachPointerEventUntilReleased { event ->
                 if (secondTouchSlop.isPast(event)) {
@@ -96,7 +100,20 @@ private suspend fun PointerInputScope.detectTransformGestures(
                             event.consumePositionChanges()
                         }
                     }
+                    isDoubleTap = false
                 }
+                if (event.changes.size > 1) {
+                    isDoubleTap = false
+                }
+                secondUp = event.changes[0]
+            }
+
+            if (secondUp.uptimeMillis - secondDown.uptimeMillis > viewConfiguration.longPressTimeoutMillis) {
+                isDoubleTap = false
+            }
+
+            if (isDoubleTap) {
+                onDoubleTap(secondUp.position)
             }
         }
     }
@@ -225,6 +242,8 @@ fun Modifier.zoomable(
                     scope.launch {
                         zoomState.endGesture()
                     }
+                },
+                onDoubleTap = {
                 },
                 enableOneFingerZoom = enableOneFingerZoom,
             )

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -243,7 +243,11 @@ fun Modifier.zoomable(
                         zoomState.endGesture()
                     }
                 },
-                onDoubleTap = {
+                onDoubleTap = { position ->
+                    scope.launch {
+                        val scale = if (zoomState.scale == 1f) 2f else 1f
+                        zoomState.changeScale(scale, position)
+                    }
                 },
                 enableOneFingerZoom = enableOneFingerZoom,
             )


### PR DESCRIPTION
## Issue

- #51 

## Description

Support double tap zoom.
Currently, the only scales that can be taken are 1 or 2.

## Plans
- [x] Make the scale value configurable.
- [x] Make it possible to disable double-tap zoom.
- [x] Add test code.