### PR TITLE
Improve instrument test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,9 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: 31
+          arch: x86_64
+          emulator-boot-timeout: 1200
           script: ./gradlew zoomable:connectedDebugAndroidTest
 
       # Download & install the Android SDK.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'main'
       - 'release*'
+      - 'action/test/*'
 
 jobs:
   unit_tests:
@@ -27,27 +28,33 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          api-level: 29
+          script: ./gradlew zoomable:connectedDebugAndroidTest
+
+#      - name: Setup Java
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '17'
+#          distribution: 'adopt'
 
       # Download & install the Android SDK.
-      - uses: malinskiy/action-android/install-sdk@release/0.1.3
+#      - uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       # Set up platform tools like adb.
-      - run: sdkmanager platform-tools
+#      - run: sdkmanager platform-tools
 
       # Start ADB (and verify that pathing is working correctly).
-      - run: adb devices
+#      - run: adb devices
 
       # Verify $ANDROID_HOME is properly set for later Gradle commands.
-      - run: echo $ANDROID_HOME
+#      - run: echo $ANDROID_HOME
 
-      - uses: malinskiy/action-android/emulator-run-cmd@release/0.1.4
-        with:
-          cmd: ./gradlew zoomable:connectedDebugAndroidTest
-          api: 25
-          tag: default
-          abi: x86
+#      - uses: malinskiy/action-android/emulator-run-cmd@release/0.1.4
+#        with:
+#          cmd: ./gradlew zoomable:connectedDebugAndroidTest
+#          api: 25
+#          tag: default
+#          abi: x86

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - 'main'
       - 'release*'
-      - 'action/test/*'
 
 jobs:
   unit_tests:
@@ -70,22 +69,3 @@ jobs:
           disable-animations: true
           emulator-boot-timeout: 1200
           script: ./gradlew zoomable:connectedDebugAndroidTest
-
-      # Download & install the Android SDK.
-#      - uses: malinskiy/action-android/install-sdk@release/0.1.4
-
-      # Set up platform tools like adb.
-#      - run: sdkmanager platform-tools
-
-      # Start ADB (and verify that pathing is working correctly).
-#      - run: adb devices
-
-      # Verify $ANDROID_HOME is properly set for later Gradle commands.
-#      - run: echo $ANDROID_HOME
-
-#      - uses: malinskiy/action-android/emulator-run-cmd@release/0.1.4
-#        with:
-#          cmd: ./gradlew zoomable:connectedDebugAndroidTest
-#          api: 25
-#          tag: default
-#          abi: x86

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,17 +28,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
           script: ./gradlew zoomable:connectedDebugAndroidTest
-
-#      - name: Setup Java
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '17'
-#          distribution: 'adopt'
 
       # Download & install the Android SDK.
 #      - uses: malinskiy/action-android/install-sdk@release/0.1.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
 
   instrument_tests:
     runs-on: macOS-latest
+    env:
+      API_LEVEL: 31
     steps:
       - uses: actions/checkout@v3
 
@@ -34,11 +36,38 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          emulator-boot-timeout: 1200
+          script: echo "Generated AVD snapshot for caching."
+
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 31
+          api-level: ${{ env.API_LEVEL }}
           arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           emulator-boot-timeout: 1200
           script: ./gradlew zoomable:connectedDebugAndroidTest
 


### PR DESCRIPTION
- Replace action from Malinskiy/action-android to ReactiveCircus/android-emulator-runner
- Use adb snapshot cache
- Change adb api level and archtecture