### PR TITLE
Pass Offset of tapped position to onTap callback of Modifier.zoomable.

### DIFF
--- a/zoomable/src/androidTest/java/net/engawapg/lib/zoomable/ZoomableTest.kt
+++ b/zoomable/src/androidTest/java/net/engawapg/lib/zoomable/ZoomableTest.kt
@@ -12,11 +12,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pinch
 import androidx.compose.ui.test.swipe
@@ -187,6 +187,8 @@ class ZoomableTest {
     @Test
     fun zoomable_tap_calledOnTap() {
         var count = 0
+        var positionAtCallback: Offset = Offset.Unspecified
+        var positionTapped: Offset = Offset.Zero
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setContent {
             val painter = painterResource(id = android.R.drawable.ic_dialog_info)
@@ -199,17 +201,22 @@ class ZoomableTest {
                     .fillMaxSize()
                     .zoomable(
                         zoomState = zoomState,
-                        onTap = {
+                        onTap = { position ->
                             count = 1
+                            positionAtCallback = position
                         },
                     )
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("image").performClick()
+        composeTestRule.onNodeWithContentDescription("image").performTouchInput {
+            positionTapped = center
+            click(positionTapped)
+        }
         // Wait manually because automatic synchronization does not work well.
         // I think the wait process to determine if it is a double-tap is judged to be idle.
         composeTestRule.mainClock.advanceTimeBy(1000L)
         assert(count == 1)
+        assert(positionAtCallback == positionTapped)
     }
 }

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -52,7 +52,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
     onGesture: (centroid: Offset, pan: Offset, zoom: Float, timeMillis: Long) -> Boolean,
     onGestureStart: () -> Unit = {},
     onGestureEnd: () -> Unit = {},
-    onTap: () -> Unit = {},
+    onTap: (position: Offset) -> Unit = {},
     onDoubleTap: (position: Offset) -> Unit = {},
     enableOneFingerZoom: Boolean = true,
 ) = awaitEachGesture {
@@ -90,7 +90,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
     if (isTap) {
         val secondDown = awaitSecondDown(firstUp)
         if (secondDown == null) {
-            onTap()
+            onTap(firstUp.position)
         } else {
             var isDoubleTap = true
             var secondUp: PointerInputChange = secondDown
@@ -223,7 +223,7 @@ private class TouchSlop(private val threshold: Float) {
 fun Modifier.zoomable(
     zoomState: ZoomState,
     enableOneFingerZoom: Boolean = true,
-    onTap: () -> Unit = {},
+    onTap: (position: Offset) -> Unit = {},
     onDoubleTap: suspend (position: Offset) -> Unit = { position -> zoomState.toggleScale(2.5f, position) },
 ): Modifier = composed(
     inspectorInfo = debugInspectorInfo {


### PR DESCRIPTION
## Issue

- close #120 

## Overview

Pass `Offset` of tapped position to `onTap` callback of `Modifier.zoomable`.

The type of onTap callback has changed from `() -> Unit` to `(Offset) -> Unit`.