### PR TITLE
Use nested scroll system to achieve both Pager swiping and zoomed image dragging

### DIFF
--- a/app/src/main/java/net/engawapg/app/zoomable/AndroidxPagerSamples.kt
+++ b/app/src/main/java/net/engawapg/app/zoomable/AndroidxPagerSamples.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import net.engawapg.lib.zoomable.ZoomableDefaults
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
@@ -26,6 +27,7 @@ fun AndroidxHorizontalPagerSample() {
     val pagerState = rememberPagerState { resources.size }
     HorizontalPager(
         state = pagerState,
+        pageNestedScrollConnection = ZoomableDefaults.pageNestedScrollConnection,
         modifier = Modifier.fillMaxSize()
     ) { page ->
         val painter = painterResource(id = resources[page])
@@ -61,6 +63,7 @@ fun AndroidxVerticalPagerSample() {
     val pagerState = rememberPagerState { resources.size }
     VerticalPager(
         state = pagerState,
+        pageNestedScrollConnection = ZoomableDefaults.pageNestedScrollConnection,
         modifier = Modifier.fillMaxSize()
     ) { page ->
         val painter = painterResource(id = resources[page])

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -69,10 +69,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
             if (zoomChange != 1f || panChange != Offset.Zero) {
                 val centroid = event.calculateCentroid(useCurrent = false)
                 val timeMillis = event.changes[0].uptimeMillis
-                val canConsume = onGesture(centroid, panChange, zoomChange, timeMillis)
-                if (canConsume) {
-                    event.consumePositionChanges()
-                }
+                onGesture(centroid, panChange, zoomChange, timeMillis)
             }
             isTap = false
         }
@@ -80,6 +77,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
             isTap = false
         }
         firstUp = event.changes[0]
+        event.consumePositionChanges()
     }
 
     if (firstUp.uptimeMillis - firstDown.uptimeMillis > viewConfiguration.longPressTimeoutMillis) {
@@ -103,10 +101,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
                         if (zoomChange != 1f) {
                             val centroid = event.calculateCentroid(useCurrent = false)
                             val timeMillis = event.changes[0].uptimeMillis
-                            val canConsume = onGesture(centroid, Offset.Zero, zoomChange, timeMillis)
-                            if (canConsume) {
-                                event.consumePositionChanges()
-                            }
+                            onGesture(centroid, Offset.Zero, zoomChange, timeMillis)
                         }
                     }
                     isDoubleTap = false
@@ -115,6 +110,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
                     isDoubleTap = false
                 }
                 secondUp = event.changes[0]
+                event.consumePositionChanges()
             }
 
             if (secondUp.uptimeMillis - secondDown.uptimeMillis > viewConfiguration.longPressTimeoutMillis) {

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -39,8 +39,7 @@ import kotlin.math.abs
  * A caller of this function can choose if the pointer events will be consumed.
  * And the caller can implement [onGestureStart] and [onGestureEnd] event.
  *
- * @param onGesture If this lambda returns true, the pointer events will be consumed. If it returns
- * false, the pointer events will not be consumed.
+ * @param onGesture Gesture handler.
  * @param onGestureStart This lambda is called when a gesture starts.
  * @param onGestureEnd This lambda is called when a gesture ends.
  * @param onTap will be called when single tap is detected.
@@ -49,7 +48,7 @@ import kotlin.math.abs
  * vertical scrolling.
  */
 private suspend fun PointerInputScope.detectTransformGestures(
-    onGesture: (centroid: Offset, pan: Offset, zoom: Float, timeMillis: Long) -> Boolean,
+    onGesture: (centroid: Offset, pan: Offset, zoom: Float, timeMillis: Long) -> Unit,
     onGestureStart: () -> Unit = {},
     onGestureEnd: () -> Unit = {},
     onTap: (position: Offset) -> Unit = {},
@@ -247,7 +246,6 @@ fun Modifier.zoomable(
                             )
                         }
                     }
-                    canConsume
                 },
                 onGestureEnd = {
                     scope.launch {

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomableDefaults.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomableDefaults.kt
@@ -1,0 +1,18 @@
+package net.engawapg.lib.zoomable
+
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+
+/**
+ * Default values used by [Modifier.zoomable()]
+ */
+object ZoomableDefaults {
+
+    /**
+     * pageNestedScrollConnection to be set to HorizontalPager or VerticalPager.
+     * If [Modifier.zoomable()] is used in Pager's contents, this should be set to Pager's
+     * pageNestedScrollConnection to enable Pager scroll.
+     *
+     * This implements nothing so that all scroll and fling events will reach the Pager.
+     */
+    val pageNestedScrollConnection = object : NestedScrollConnection {}
+}


### PR DESCRIPTION
## Issue

- close #93 

## Overview

As described in the issue #93, pinch gestures sometimes caused expanding the image and swiping the pages concurrently.
This pull request resolve it by using the nested scroll system instead of controlling cosumption of `PointerInputEvent`s.

## Before

If the detected `PointerInputEvent`s were recognized as a pinch gesture, `Modifier.zoomable()` consumed them to enlarge the image.
On the other hands, if they were recognized as a swipe gesture, `Modifier.zoomable()` didn't consume them and propagated them to the Pager.
However, the event was propagated to the Pager until the determination of whether the gesture was a pinch gesture or a swipe gesture was completed.
If the gesture was determined to be a pinch gesture after several `PointerInputEvent`s were propagated to the Pager, both the Pager swipe and the image enlargement were occurring simultaneously.

## After

Now `Modifier.zoomable()` consumes all of `PointerInputEvent`s.
After `Modifier.zoomable()` determines that the gesture is a swipe gesture, it issues a scroll event using `NestedScrollDispatcher`.

## API Change

Pass `ZoomableDefault.pageNestedScrollConnection` to Pager when you apply `Modifier.zoomable()` to the contents on the Pager.

```
HorizontalPager(
    pageNestedScrollConnection = ZoomableDefaults.pageNestedScrollConnection,
) {
    Image(modifier = Modifier.zoomable(zoomState))
}
```