### PR TITLE
Use current position to calculate velocity

### DIFF
--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -67,7 +67,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
             val zoomChange = event.calculateZoom()
             val panChange = event.calculatePan()
             if (zoomChange != 1f || panChange != Offset.Zero) {
-                val centroid = event.calculateCentroid(useCurrent = false)
+                val centroid = event.calculateCentroid(useCurrent = true)
                 val timeMillis = event.changes[0].uptimeMillis
                 val canConsume = onGesture(centroid, panChange, zoomChange, timeMillis)
                 if (canConsume) {
@@ -101,7 +101,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
                         val panChange = event.calculatePan()
                         val zoomChange = 1f + panChange.y * 0.004f
                         if (zoomChange != 1f) {
-                            val centroid = event.calculateCentroid(useCurrent = false)
+                            val centroid = event.calculateCentroid(useCurrent = true)
                             val timeMillis = event.changes[0].uptimeMillis
                             val canConsume = onGesture(centroid, Offset.Zero, zoomChange, timeMillis)
                             if (canConsume) {

--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -201,7 +201,7 @@ private class TouchSlop(private val threshold: Float) {
 
         zoom *= event.calculateZoom()
         pan += event.calculatePan()
-        val zoomMotion = abs(1 - zoom) * event.calculateCentroidSize(useCurrent = false)
+        val zoomMotion = abs(1 - zoom) * event.calculateCentroidSize(useCurrent = true)
         val panMotion = pan.getDistance()
         _isPast = zoomMotion > threshold || panMotion > threshold
 


### PR DESCRIPTION
## Issue

- close #136 

## Description

Previously, the coordinates of touch position were caluculated from pointer events one sample ago.
Now, it's caluculated using current pointer events.