### PR TITLE
Make maxScale public

### DIFF
--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/ZoomState.kt
@@ -48,7 +48,7 @@ import kotlin.math.abs
  */
 @Stable
 class ZoomState(
-    @FloatRange(from = 1.0) private val maxScale: Float = 5f,
+    @FloatRange(from = 1.0) val maxScale: Float = 5f,
     private var contentSize: Size = Size.Zero,
     private val velocityDecay: DecayAnimationSpec<Float> = exponentialDecay(),
 ) {


### PR DESCRIPTION
This PR makes `maxScale` of `ZoomState` public.
The reason is refered in #193.