### PR TITLE
Call onCancel when mainEvent is consumed

### DIFF
--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -170,6 +170,7 @@ private suspend fun AwaitPointerEventScope.forEachPointerEventUntilReleased(
     do {
         val mainEvent = awaitPointerEvent(pass = PointerEventPass.Main)
         if (mainEvent.changes.fastAny { it.isConsumed }) {
+            onCancel()
             break
         }
 


### PR DESCRIPTION
Fixes https://github.com/usuiat/Zoomable/issues/232

In https://github.com/usuiat/Zoomable/pull/180 cancelation of consumed events was added, the check was only done for the finalEvent but not for the mainEvent.