### PR TITLE
Fix tap conflict

### DIFF
--- a/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/net/engawapg/lib/zoomable/Zoomable.kt
@@ -73,6 +73,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
     enableOneFingerZoom: Boolean = true,
 ) = awaitEachGesture {
     val firstDown = awaitFirstDown(requireUnconsumed = false)
+    firstDown.consume()
     onGestureStart()
 
     var firstUp: PointerInputChange = firstDown
@@ -113,6 +114,7 @@ private suspend fun PointerInputScope.detectTransformGestures(
         if (secondDown == null) {
             onTap(firstUp.position)
         } else {
+            secondDown.consume()
             var isDoubleTap = true
             var isSecondCanceled = false
             var secondUp: PointerInputChange = secondDown


### PR DESCRIPTION
fix #238 

In v1.6.1, onTap and onDoubleTap of zoomable did not work if the parent composable was clickable.
This is because zoomable was canceling gesture processing when the parent composable consumed a click event.

In this PR, zoomable will consume the down event.
As a result, the parent's clickable will not work and zoomable's onTap and onDoubleTap will work.