### PR TITLE
Use coil-network-ktor2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Perform tests a
+name: Perform tests
 
 on:
   pull_request:
@@ -18,6 +18,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Verify gradle dependencies
+        run: ./gradlew --refresh-dependencies dependencies
 
       - name: Run tests
         run: ./gradlew zoomable:testDebugUnitTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Verify gradle dependencies
-        run: ./gradlew --refresh-dependencies dependencies
+      - name: Build
+        run: ./gradlew :composeApp:assembleDebug
 
       - name: Run tests
         run: ./gradlew zoomable:testDebugUnitTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Perform tests
+name: Perform tests a
 
 on:
   pull_request:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ accompanist-pager = { module = "com.google.accompanist:accompanist-pager", versi
 accompanist-pager-indicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
-coil-network = { module = "io.coil-kt.coil3:coil-network-ktor", version.ref = "coil" }
+coil-network = { module = "io.coil-kt.coil3:coil-network-ktor2", version.ref = "coil" }
 
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
Use coil-network-ktor2 instead of coil-network-ktor because it was renamed.
ref: https://github.com/coil-kt/coil/blob/main/CHANGELOG.md#300-alpha09---july-23-2024

Additionally, modified the test workflow to detect situations that would cause a build to fail.