### PR TITLE
Fixed a problem in which the behavior of zoomable did not change after changing the argument

### DIFF
--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
@@ -206,7 +206,7 @@ private class ZoomableNode(
     val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode {
             detectZoomableGestures(
-                cancelIfZoomCanceled = snapBackEnabled,
+                cancelIfZoomCanceled = { snapBackEnabled },
                 onGestureStart = {
                     resetConsumeGesture()
                     zoomState.startGesture()
@@ -235,14 +235,14 @@ private class ZoomableNode(
                         }
                     }
                 },
-                onTap = onTap,
+                onTap = { onTap(it) },
                 onDoubleTap = { position ->
                     coroutineScope.launch {
                         onDoubleTap(position)
                     }
                 },
-                onLongPress = onLongPress,
-                enableOneFingerZoom = enableOneFingerZoom,
+                onLongPress = { onLongPress(it) },
+                enableOneFingerZoom = { enableOneFingerZoom },
             )
         }
     )

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/DetectZoomableGesturesTest.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/DetectZoomableGesturesTest.kt
@@ -33,9 +33,6 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
     private val ViewConfiguration.tapDetermineDelay: Long
         get() = doubleTapTimeoutMillis * 2
 
-    private val ViewConfiguration.doubleTapDelay: Long
-        get() = (doubleTapMinTimeMillis + doubleTapTimeoutMillis) / 2
-
     private fun SemanticsNodeInteraction.performGesture(gesture: TouchInjectionScope.() -> Unit) {
         performTouchInput {
             gesture()
@@ -49,27 +46,6 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
     private fun TouchInjectionScope.pan(x: Float = 0f, y: Float = 0f) {
         down(center)
         moveBy(Offset(x, y))
-        up()
-    }
-
-    private fun TouchInjectionScope.pinchZoom(zoom: Float) {
-        val startDistance = 100f
-        down(0, center + Offset(startDistance / 2, 0f))
-        down(1, center - Offset(startDistance / 2, 0f))
-        val endDistance = startDistance * zoom
-        moveTo(0, center + Offset(endDistance / 2, 0f))
-        moveTo(1, center - Offset(endDistance / 2, 0f))
-        up(0)
-        up(1)
-    }
-
-    private fun TouchInjectionScope.tapAndDragZoom(zoom: Float) {
-        down(center)
-        up()
-        advanceEventTime(viewConfiguration.doubleTapDelay)
-        down(center)
-        val y = (zoom - 1f) / 0.004f
-        moveBy(Offset(0f, y))
         up()
     }
 
@@ -95,7 +71,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                     .size(300.dp)
                     .pointerInput(Unit) {
                         detectZoomableGestures(
-                            cancelIfZoomCanceled = cancelIfZoomCanceled,
+                            cancelIfZoomCanceled = { cancelIfZoomCanceled },
                             canConsumeGesture = canConsumeGesture,
                             onGesture = { _, pan, zoom, _ ->
                                 result.pan += pan
@@ -104,7 +80,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                             onTap = { result.tap++ },
                             onDoubleTap = { result.doubleTap++ },
                             onLongPress = { result.longPress++ },
-                            enableOneFingerZoom = enableOneFingerZoom,
+                            enableOneFingerZoom = { enableOneFingerZoom },
                         )
                     }
             )
@@ -141,7 +117,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                         .size(300.dp)
                         .pointerInput(Unit) {
                             detectZoomableGestures(
-                                cancelIfZoomCanceled = cancelIfZoomCanceled,
+                                cancelIfZoomCanceled = { cancelIfZoomCanceled },
                                 canConsumeGesture = canConsumeGesture,
                                 onGesture = { _, pan, zoom, _ ->
                                     result.pan += pan
@@ -150,7 +126,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                                 onTap = { result.tap++ },
                                 onDoubleTap = { result.doubleTap++ },
                                 onLongPress = { result.longPress++ },
-                                enableOneFingerZoom = enableOneFingerZoom,
+                                enableOneFingerZoom = { enableOneFingerZoom },
                             )
                         }
                 ) {

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/Gesture.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/Gesture.kt
@@ -1,0 +1,29 @@
+package net.engawapg.lib.zoomable
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.test.TouchInjectionScope
+
+val ViewConfiguration.doubleTapDelay: Long
+    get() = (doubleTapMinTimeMillis + doubleTapTimeoutMillis) / 2
+
+fun TouchInjectionScope.pinchZoom(zoom: Float) {
+    val startDistance = 100f
+    down(0, center + Offset(startDistance / 2, 0f))
+    down(1, center - Offset(startDistance / 2, 0f))
+    val endDistance = startDistance * zoom
+    moveTo(0, center + Offset(endDistance / 2, 0f))
+    moveTo(1, center - Offset(endDistance / 2, 0f))
+    up(0)
+    up(1)
+}
+
+fun TouchInjectionScope.tapAndDragZoom(zoom: Float) {
+    down(center)
+    up()
+    advanceEventTime(viewConfiguration.doubleTapDelay)
+    down(center)
+    val y = (zoom - 1f) / 0.004f
+    moveBy(Offset(0f, y))
+    up()
+}

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomableTest.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomableTest.kt
@@ -4,11 +4,15 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -387,4 +391,42 @@ class ZoomableTest : PlatformZoomableTest() {
             assertEquals(boundsAfter.width, boundsBefore.width)
             assertEquals(boundsAfter.height, boundsBefore.height)
         }
+
+    @Test
+    fun enableOneFingerZoom_can_be_changed() = runComposeUiTest {
+        var enableOneFingerZoom by mutableStateOf(true)
+        setContent {
+            val icon = Icons.Default.Info
+            val zoomState =
+                rememberZoomState(contentSize = Size(icon.viewportWidth, icon.viewportHeight))
+            Image(
+                imageVector = icon,
+                contentDescription = "image",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .size(300.dp)
+                    .zoomable(
+                        zoomState = zoomState,
+                        enableOneFingerZoom = enableOneFingerZoom,
+                    )
+            )
+        }
+
+        val node = onNodeWithContentDescription("image")
+        val boundsBefore = node.fetchSemanticsNode().boundsInRoot
+        node.performTouchInput {
+            tapAndDragZoom(1.5f)
+        }
+        val boundsResult1 = node.fetchSemanticsNode().boundsInRoot
+        assertTrue(boundsResult1.width > boundsBefore.width)
+        assertTrue(boundsResult1.height > boundsBefore.height)
+
+        enableOneFingerZoom = false
+        node.performTouchInput {
+            tapAndDragZoom(1.5f)
+        }
+        val boundsResult2 = node.fetchSemanticsNode().boundsInRoot
+        assertEquals(boundsResult2.width, boundsResult1.width)
+        assertEquals(boundsResult2.height, boundsResult1.height)
+    }
 }


### PR DESCRIPTION
This PR fixed a problem that changing the following argments after first composition does not chage the `zoomable` behaviour

- `enableOneFingerZoom`
- `onTap`
- `onLongPress`

Fix #316 