### PR TITLE
Add initialScale parameter to ZoomState

### DIFF
--- a/composeApp/src/androidMain/kotlin/net/engawapg/app/zoomable/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/engawapg/app/zoomable/MainActivity.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import net.engawapg.app.zoomable.theme.ZoomableTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,4 +23,18 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun AppAndroidPreview() {
     App()
+}
+
+@Preview
+@Composable
+fun SettingsBottomSheetPreview() {
+    ZoomableTheme {
+        Column {
+            SettingsContent(
+                settings = Settings(),
+                onSettingsChange = {},
+                onDoneClick = {},
+            )
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/App.kt
@@ -170,7 +170,7 @@ private fun SampleTypeSelectionBottomSheet(
     ) {
         Text(
             text = "Samples",
-            style = MaterialTheme.typography.titleMedium,
+            style = MaterialTheme.typography.titleLarge,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
         Spacer(modifier = Modifier.height(4.dp))

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/BasicSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/BasicSample.kt
@@ -17,6 +17,7 @@ fun BasicSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offse
     val painter = painterResource(resource = Res.drawable.penguin)
     val zoomState = rememberZoomState(
         contentSize = painter.intrinsicSize,
+        initialScale = settings.initialScale,
     )
     Image(
         painter = painter,

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/CoilSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/CoilSample.kt
@@ -11,7 +11,7 @@ import net.engawapg.lib.zoomable.zoomable
 
 @Composable
 fun CoilSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
-    val zoomState = rememberZoomState()
+    val zoomState = rememberZoomState(initialScale = settings.initialScale)
     AsyncImage(
         model = "https://github.com/usuiat.png",
         contentDescription = "GitHub icon",

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/PagerSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/PagerSample.kt
@@ -25,7 +25,10 @@ fun PagerSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offse
         modifier = Modifier.fillMaxSize()
     ) { page ->
         val painter = painterResource(resource = resources[page])
-        val zoomState = rememberZoomState(contentSize = painter.intrinsicSize)
+        val zoomState = rememberZoomState(
+            contentSize = painter.intrinsicSize,
+            initialScale = settings.initialScale,
+        )
         Image(
             painter = painter,
             contentDescription = "Zoomable image",

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/Settings.kt
@@ -2,7 +2,9 @@ package net.engawapg.app.zoomable
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,6 +29,7 @@ data class Settings(
     val zoomEnabled: Boolean = true,
     val enableOneFingerZoom: Boolean = true,
     val scrollGesturePropagation: ScrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+    val initialScale: Float = 1f,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,73 +45,111 @@ fun SettingsBottomSheet(
         sheetState = sheetState,
         onDismissRequest = onDismissRequest,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp)
-        ) {
-            Text(
-                text = "Settings",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.weight(1f)
-            )
-            TextButton(
-                onClick = {
-                    scope
-                        .launch { sheetState.hide() }
-                        .invokeOnCompletion {
-                            if (!sheetState.isVisible) {
-                                onDismissRequest()
-                            }
+        SettingsContent(
+            settings = settings,
+            onSettingsChange = onSettingsChange,
+            onDoneClick = {
+                scope
+                    .launch { sheetState.hide() }
+                    .invokeOnCompletion {
+                        if (!sheetState.isVisible) {
+                            onDismissRequest()
                         }
-                }
-            ) {
-                Text("Done")
+                    }
             }
-        }
-
-        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-
-        SwitchSettingItem(
-            text = "zoomEnabled",
-            checked = settings.zoomEnabled,
-            onCheckedChange = {
-                onSettingsChange(settings.copy(zoomEnabled = it))
-            },
-        )
-        SwitchSettingItem(
-            text = "enableOneFingerZoom",
-            checked = settings.enableOneFingerZoom,
-            onCheckedChange = {
-                onSettingsChange(settings.copy(enableOneFingerZoom = it))
-            },
-        )
-
-        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-
-        Text(
-            text = "scrollGesturePropagation",
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-        )
-        RadioButtonSettingItem(
-            text = "ContentEdge",
-            selected = settings.scrollGesturePropagation == ScrollGesturePropagation.ContentEdge,
-            onClick = {
-                onSettingsChange(
-                    settings.copy(scrollGesturePropagation = ScrollGesturePropagation.ContentEdge)
-                )
-            },
-        )
-        RadioButtonSettingItem(
-            text = "NotZoomed",
-            selected = settings.scrollGesturePropagation == ScrollGesturePropagation.NotZoomed,
-            onClick = {
-                onSettingsChange(
-                    settings.copy(scrollGesturePropagation = ScrollGesturePropagation.NotZoomed)
-                )
-            },
         )
     }
+}
+
+@Composable
+internal fun SettingsContent(
+    settings: Settings,
+    onSettingsChange: (Settings) -> Unit,
+    onDoneClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.weight(1f)
+        )
+        TextButton(onClick = onDoneClick) {
+            Text("Done")
+        }
+    }
+
+    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+    SwitchSettingItem(
+        text = "zoomEnabled",
+        checked = settings.zoomEnabled,
+        onCheckedChange = {
+            onSettingsChange(settings.copy(zoomEnabled = it))
+        },
+    )
+    SwitchSettingItem(
+        text = "enableOneFingerZoom",
+        checked = settings.enableOneFingerZoom,
+        onCheckedChange = {
+            onSettingsChange(settings.copy(enableOneFingerZoom = it))
+        },
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+    Text(
+        text = "scrollGesturePropagation",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+    RadioButtonSettingItem(
+        text = "ContentEdge",
+        selected = settings.scrollGesturePropagation == ScrollGesturePropagation.ContentEdge,
+        onClick = {
+            onSettingsChange(
+                settings.copy(scrollGesturePropagation = ScrollGesturePropagation.ContentEdge)
+            )
+        },
+    )
+    RadioButtonSettingItem(
+        text = "NotZoomed",
+        selected = settings.scrollGesturePropagation == ScrollGesturePropagation.NotZoomed,
+        onClick = {
+            onSettingsChange(
+                settings.copy(scrollGesturePropagation = ScrollGesturePropagation.NotZoomed)
+            )
+        },
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+    Text(
+        text = "initialScale",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+    Text(
+        text = "To reflect the changed values, switch the sample to be displayed.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    RadioButtonSettingItem(
+        text = "1.0",
+        selected = settings.initialScale == 1f,
+        onClick = { onSettingsChange(settings.copy(initialScale = 1f)) },
+    )
+    RadioButtonSettingItem(
+        text = "2.0",
+        selected = settings.initialScale == 2f,
+        onClick = { onSettingsChange(settings.copy(initialScale = 2f)) },
+    )
+
+    Spacer(modifier = Modifier.height(24.dp))
 }
 
 @Composable
@@ -128,7 +169,7 @@ private fun SwitchSettingItem(
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.weight(1f)
         )
         Switch(

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/ZoomState.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/ZoomState.kt
@@ -45,18 +45,21 @@ import kotlinx.coroutines.launch
  * @param contentSize Size of content (i.e. image size.) If Zero, the composable layout size will
  * be used as content size.
  * @param velocityDecay The decay animation spec for fling behaviour.
+ * @param initialScale The initial scale of the content.
  */
 @Stable
 class ZoomState(
     @FloatRange(from = 1.0) val maxScale: Float = 5f,
     private var contentSize: Size = Size.Zero,
     private val velocityDecay: DecayAnimationSpec<Float> = exponentialDecay(),
+    @FloatRange(from = 1.0) private val initialScale: Float = 1f,
 ) {
     init {
         require(maxScale >= 1.0f) { "maxScale must be at least 1.0." }
+        require(initialScale >= 1.0f) { "initialScale must be at least 1.0." }
     }
 
-    private var _scale = Animatable(1f).apply {
+    private var _scale = Animatable(initialScale).apply {
         updateBounds(0.9f, maxScale)
     }
 
@@ -132,7 +135,7 @@ class ZoomState(
      * Reset the scale and the offsets.
      */
     suspend fun reset() = coroutineScope {
-        launch { _scale.snapTo(1f) }
+        launch { _scale.snapTo(initialScale) }
         _offsetX.updateBounds(0f, 0f)
         launch { _offsetX.snapTo(0f) }
         _offsetY.updateBounds(0f, 0f)
@@ -385,12 +388,14 @@ class ZoomState(
  * @param contentSize Size of content (i.e. image size.) If Zero, the composable layout size will
  * be used as content size.
  * @param velocityDecay The decay animation spec for fling behaviour.
+ * @param initialScale The initial scale of the content.
  */
 @Composable
 fun rememberZoomState(
     @FloatRange(from = 1.0) maxScale: Float = 5f,
     contentSize: Size = Size.Zero,
     velocityDecay: DecayAnimationSpec<Float> = exponentialDecay(),
+    @FloatRange(from = 1.0) initialScale: Float = 1f,
 ) = remember {
-    ZoomState(maxScale, contentSize, velocityDecay)
+    ZoomState(maxScale, contentSize, velocityDecay, initialScale)
 }

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomStateTest.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomStateTest.kt
@@ -33,6 +33,12 @@ class ZoomStateTest {
     }
 
     @Test
+    fun zoomState_is_initialized_with_arbitrary_scale() {
+        val zoomState = ZoomState(initialScale = 2.0f)
+        assertEquals(zoomState.scale, 2.0f)
+    }
+
+    @Test
     fun applyGesture_enlargeToGreaterThanMax_enlargesToMax() = runTest {
         val zoomState = ZoomState(contentSize = Size(100f, 100f))
         zoomState.setLayoutSize(Size(100f, 100f))


### PR DESCRIPTION
Added `initialScale` parameter to the `ZoomState` and `rememberZoomState` to allow display at an arbitrary scale from the beginning.

### Related Issue
- #253 