### PR TITLE
Change Maven POM name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=net.engawapg.lib
 POM_ARTIFACT_ID=zoomable
-VERSION_NAME=2.1.0
+VERSION_NAME=2.2.0-beta01
 
 POM_NAME=net.engawapg.lib:zoomable
 POM_DESCRIPTION=An android library for Jetpack Compose that enables contents zoomable.

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ GROUP=net.engawapg.lib
 POM_ARTIFACT_ID=zoomable
 VERSION_NAME=2.2.0-beta01
 
-POM_NAME=net.engawapg.lib:zoomable
+POM_NAME=Engawapg Zoomable
 POM_DESCRIPTION=An android library for Jetpack Compose that enables contents zoomable.
 POM_INCEPTION_YEAR=2022
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ GROUP=net.engawapg.lib
 POM_ARTIFACT_ID=zoomable
 VERSION_NAME=2.1.0
 
-POM_NAME=zoomable
+POM_NAME=net.engawapg.lib:zoomable
 POM_DESCRIPTION=An android library for Jetpack Compose that enables contents zoomable.
 POM_INCEPTION_YEAR=2022
 


### PR DESCRIPTION
Since there are several libraries named “zoomable,” I change the POM name to distinguish this library from them.