### PR TITLE
Improve tap response when double tap and one finger zoom are disabled

### DIFF
--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
@@ -102,6 +102,11 @@ private suspend fun AwaitPointerEventScope.detectGesture(
     }
     val firstUp = event.changes[0]
 
+    if (onDoubleTap == null && !enableOneFingerZoom()) {
+        onTap?.invoke(firstUp.position)
+        return
+    }
+
     val secondDown = awaitSecondDown(firstUp)
     if (secondDown == null) {
         onTap?.invoke(firstUp.position)

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
@@ -77,11 +77,11 @@ public fun Modifier.zoomable(
     zoomEnabled: Boolean = true,
     enableOneFingerZoom: Boolean = true,
     scrollGesturePropagation: ScrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
-    onTap: (position: Offset) -> Unit = {},
-    onDoubleTap: suspend (
-        position: Offset,
-    ) -> Unit = { position -> if (zoomEnabled) zoomState.toggleScale(2.5f, position) },
-    onLongPress: (position: Offset) -> Unit = {},
+    onTap: ((position: Offset) -> Unit)? = null,
+    onDoubleTap: (suspend (position: Offset) -> Unit)? = { position ->
+        if (zoomEnabled) zoomState.toggleScale(2.5f, position)
+    },
+    onLongPress: ((position: Offset) -> Unit)? = null,
     mouseWheelZoom: MouseWheelZoom = MouseWheelZoom.EnabledWithCtrlKey,
 ): Modifier = this then ZoomableElement(
     zoomState = zoomState,
@@ -131,9 +131,9 @@ private data class ZoomableElement(
     val enableOneFingerZoom: Boolean,
     val snapBackEnabled: Boolean,
     val scrollGesturePropagation: ScrollGesturePropagation,
-    val onTap: (position: Offset) -> Unit,
-    val onDoubleTap: suspend (position: Offset) -> Unit,
-    val onLongPress: (position: Offset) -> Unit,
+    val onTap: ((position: Offset) -> Unit)?,
+    val onDoubleTap: (suspend (position: Offset) -> Unit)?,
+    val onLongPress: ((position: Offset) -> Unit)?,
     val mouseWheelZoom: MouseWheelZoom,
 ) : ModifierNodeElement<ZoomableNode>() {
     override fun create(): ZoomableNode = ZoomableNode(
@@ -182,9 +182,9 @@ private class ZoomableNode(
     var enableOneFingerZoom: Boolean,
     var snapBackEnabled: Boolean,
     var scrollGesturePropagation: ScrollGesturePropagation,
-    var onTap: (position: Offset) -> Unit,
-    var onDoubleTap: suspend (position: Offset) -> Unit,
-    var onLongPress: (position: Offset) -> Unit,
+    var onTap: ((position: Offset) -> Unit)?,
+    var onDoubleTap: (suspend (position: Offset) -> Unit)?,
+    var onLongPress: ((position: Offset) -> Unit)?,
     var mouseWheelZoom: MouseWheelZoom,
 ) : PointerInputModifierNode, LayoutModifierNode, DelegatingNode() {
     var measuredSize = Size.Zero
@@ -195,9 +195,9 @@ private class ZoomableNode(
         enableOneFingerZoom: Boolean,
         snapBackEnabled: Boolean,
         scrollGesturePropagation: ScrollGesturePropagation,
-        onTap: (position: Offset) -> Unit,
-        onDoubleTap: suspend (position: Offset) -> Unit,
-        onLongPress: (position: Offset) -> Unit,
+        onTap: ((position: Offset) -> Unit)?,
+        onDoubleTap: (suspend (position: Offset) -> Unit)?,
+        onLongPress: ((position: Offset) -> Unit)?,
         mouseWheelZoom: MouseWheelZoom,
     ) {
         if (this.zoomState != zoomState) {
@@ -246,13 +246,13 @@ private class ZoomableNode(
                         }
                     }
                 },
-                onTap = { onTap(it) },
+                onTap = { onTap?.invoke(it) },
                 onDoubleTap = { position ->
                     coroutineScope.launch {
-                        onDoubleTap(position)
+                        onDoubleTap?.invoke(position)
                     }
                 },
-                onLongPress = { onLongPress(it) },
+                onLongPress = { onLongPress?.invoke(it) },
                 enableOneFingerZoom = { enableOneFingerZoom },
             )
         }

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
@@ -110,9 +110,9 @@ public fun Modifier.zoomable(
 public fun Modifier.snapBackZoomable(
     zoomState: ZoomState,
     zoomEnabled: Boolean = true,
-    onTap: (position: Offset) -> Unit = {},
-    onDoubleTap: suspend (position: Offset) -> Unit = {},
-    onLongPress: (position: Offset) -> Unit = {},
+    onTap: ((position: Offset) -> Unit)? = null,
+    onDoubleTap: (suspend (position: Offset) -> Unit)? = null,
+    onLongPress: ((position: Offset) -> Unit)? = null,
 ): Modifier = this then ZoomableElement(
     zoomState = zoomState,
     zoomEnabled = zoomEnabled,

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
@@ -208,6 +208,12 @@ private class ZoomableNode(
         this.enableOneFingerZoom = enableOneFingerZoom
         this.scrollGesturePropagation = scrollGesturePropagation
         this.snapBackEnabled = snapBackEnabled
+        if (((onTap == null) != (this.onTap == null)) ||
+            ((onDoubleTap == null) != (this.onDoubleTap == null)) ||
+            ((onLongPress == null) != (this.onLongPress == null))
+        ) {
+            this.pointerInputNode.resetPointerInputHandler()
+        }
         this.onTap = onTap
         this.onDoubleTap = onDoubleTap
         this.onLongPress = onLongPress
@@ -246,13 +252,21 @@ private class ZoomableNode(
                         }
                     }
                 },
-                onTap = { onTap?.invoke(it) },
-                onDoubleTap = { position ->
-                    coroutineScope.launch {
-                        onDoubleTap?.invoke(position)
-                    }
+                onTap = if (onTap != null) {
+                    { onTap?.invoke(it) }
+                } else {
+                    null
                 },
-                onLongPress = { onLongPress?.invoke(it) },
+                onDoubleTap = if (onDoubleTap != null) {
+                    { coroutineScope.launch { onDoubleTap?.invoke(it) } }
+                } else {
+                    null
+                },
+                onLongPress = if (onLongPress != null) {
+                    { onLongPress?.invoke(it) }
+                } else {
+                    null
+                },
                 enableOneFingerZoom = { enableOneFingerZoom },
             )
         }


### PR DESCRIPTION
## Related Issue

- fix #329 

## Description

- onTap, onDoubleTap, and onLongPress callbacks now accept null.
- When onDoubleTap is null and enableOneFingerZoom is false, onTap will be called immediately. No longer wait the double tap detection timeout.