### PR TITLE
If Zoomable does not need to handle taps, allow the parent composable to handle them.

### DIFF
--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
@@ -45,7 +45,9 @@ internal suspend fun PointerInputScope.detectZoomableGestures(
     onLongPress: ((position: Offset) -> Unit)? = null,
 ) = awaitEachGesture {
     val firstDown = awaitFirstDown(requireUnconsumed = false)
-    firstDown.consume()
+    if (onTap != null || onDoubleTap != null || onLongPress != null || enableOneFingerZoom()) {
+        firstDown.consume()
+    }
     onGestureStart()
     detectGesture(
         cancelIfZoomCanceled = cancelIfZoomCanceled,

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomableTest.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/ZoomableTest.kt
@@ -323,6 +323,38 @@ class ZoomableTest : PlatformZoomableTest() {
     }
 
     @Test
+    fun tap_gesture_on_parent_composable_works_if_zoomable_tap_is_disabled() = runComposeUiTest {
+        var parentClickCount = 0
+        setContent {
+            Box(modifier = Modifier.clickable { parentClickCount++ }) {
+                val icon = Icons.Default.Info
+                val zoomState =
+                    rememberZoomState(contentSize = Size(icon.viewportWidth, icon.viewportHeight))
+                Image(
+                    imageVector = icon,
+                    contentDescription = "image",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .size(300.dp)
+                        .zoomable(
+                            zoomState = zoomState,
+                            enableOneFingerZoom = false,
+                            onTap = null,
+                            onLongPress = null,
+                            onDoubleTap = null,
+                        )
+                )
+            }
+        }
+
+        onNodeWithContentDescription("image").performTouchInput {
+            click()
+        }
+
+        assertEquals(1, parentClickCount)
+    }
+
+    @Test
     fun scroll_gesture_propagation_content_edge_enables_to_swipe_page_on_content_edge() =
         runComposeUiTest {
             val images = zoomableImagesOnPager(


### PR DESCRIPTION
## Related Issue 

- fix #333 

## Description

If `onTap`, `onDoubleTap`, and `onLongPress` are null and `enableOneFingerZoom` is false, `zoomable` no longer consumes the first down event. This allows the parent composable to handle the click event.