### PR TITLE
Add onLongPressReleased method + tests

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/App.kt
@@ -42,6 +42,7 @@ import zoomable_root.composeapp.generated.resources.settings_24dp
 
 sealed interface SampleType {
     val title: String
+
     data class Basic(override val title: String = "Basic sample") : SampleType
     data class Coil(override val title: String = "Coil AsyncImage") : SampleType
     data class Pager(override val title: String = "Images on HorizontalPager") : SampleType
@@ -76,36 +77,50 @@ fun App() {
                 val onLongPress = { position: Offset ->
                     message = "Long pressed (${position.x.toInt()}, ${position.y.toInt()})"
                 }
+                val onLongPressReleased = { position: Offset ->
+                    message = "Long press released (${position.x.toInt()}, ${position.y.toInt()})"
+                }
                 when (sampleType) {
                     is SampleType.Basic -> BasicSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
+
                     is SampleType.Coil -> CoilSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
+
                     is SampleType.Pager -> PagerSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
+
                     is SampleType.SnapBack -> SnapBackSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
+
                     is SampleType.LazyColumn -> LazyColumnSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
+
                     is SampleType.ScrollableRow -> ScrollableRowSample(
                         settings = settings,
                         onTap = onTap,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        onLongPressReleased = onLongPressReleased,
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/BasicSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/BasicSample.kt
@@ -13,7 +13,12 @@ import zoomable_root.composeapp.generated.resources.Res
 import zoomable_root.composeapp.generated.resources.penguin
 
 @Composable
-fun BasicSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
+fun BasicSample(
+    settings: Settings,
+    onTap: (Offset) -> Unit,
+    onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
+) {
     val painter = painterResource(resource = Res.drawable.penguin)
     val zoomState = rememberZoomState(
         contentSize = painter.intrinsicSize,
@@ -31,6 +36,7 @@ fun BasicSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offse
                 enableOneFingerZoom = settings.enableOneFingerZoom,
                 onTap = onTap,
                 onLongPress = onLongPress,
+                onLongPressReleased = onLongPressReleased,
                 mouseWheelZoom = settings.mouseWheelZoom,
             ),
     )

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/CoilSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/CoilSample.kt
@@ -10,7 +10,12 @@ import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
 @Composable
-fun CoilSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
+fun CoilSample(
+    settings: Settings,
+    onTap: (Offset) -> Unit,
+    onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
+) {
     val zoomState = rememberZoomState(initialScale = settings.initialScale)
     AsyncImage(
         model = "https://github.com/usuiat.png",
@@ -27,6 +32,7 @@ fun CoilSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset
                 enableOneFingerZoom = settings.enableOneFingerZoom,
                 onTap = onTap,
                 onLongPress = onLongPress,
+                onLongPressReleased = onLongPressReleased,
                 mouseWheelZoom = settings.mouseWheelZoom,
             ),
     )

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/LazyColumnSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/LazyColumnSample.kt
@@ -24,7 +24,12 @@ import net.engawapg.lib.zoomable.zoomableWithScroll
 
 @OptIn(ExperimentalZoomableApi::class)
 @Composable
-fun LazyColumnSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
+fun LazyColumnSample(
+    settings: Settings,
+    onTap: (Offset) -> Unit,
+    onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
+) {
     val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
     val contentPadding = PaddingValues(
         top = systemBarsPadding.calculateTopPadding(),
@@ -41,6 +46,7 @@ fun LazyColumnSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (
                 enableOneFingerZoom = settings.enableOneFingerZoom,
                 onTap = onTap,
                 onLongPress = onLongPress,
+                onLongPressReleased = onLongPressReleased,
             )
     ) {
         items(10) {

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/PagerSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/PagerSample.kt
@@ -17,7 +17,12 @@ import zoomable_root.composeapp.generated.resources.duck2
 import zoomable_root.composeapp.generated.resources.duck3
 
 @Composable
-fun PagerSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
+fun PagerSample(
+    settings: Settings,
+    onTap: (Offset) -> Unit,
+    onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
+) {
     val resources = listOf(Res.drawable.duck1, Res.drawable.duck2, Res.drawable.duck3)
     val pagerState = rememberPagerState { resources.size }
     HorizontalPager(
@@ -42,6 +47,7 @@ fun PagerSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offse
                     scrollGesturePropagation = settings.scrollGesturePropagation,
                     onTap = onTap,
                     onLongPress = onLongPress,
+                    onLongPressReleased = onLongPressReleased,
                     mouseWheelZoom = settings.mouseWheelZoom,
                 )
         )

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/ScrollableRowSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/ScrollableRowSample.kt
@@ -28,6 +28,7 @@ fun ScrollableRowSample(
     settings: Settings,
     onTap: (Offset) -> Unit,
     onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -40,6 +41,7 @@ fun ScrollableRowSample(
                 enableOneFingerZoom = settings.enableOneFingerZoom,
                 onTap = onTap,
                 onLongPress = onLongPress,
+                onLongPressReleased = onLongPressReleased,
             )
             .horizontalScroll(state = rememberScrollState())
     ) {
@@ -72,6 +74,7 @@ fun ScrollableRowSamplePreview() {
                 settings = Settings(),
                 onTap = {},
                 onLongPress = {},
+                onLongPressReleased = {},
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/SnapBackSample.kt
+++ b/composeApp/src/commonMain/kotlin/net/engawapg/app/zoomable/SnapBackSample.kt
@@ -13,7 +13,12 @@ import zoomable_root.composeapp.generated.resources.Res
 import zoomable_root.composeapp.generated.resources.bird1
 
 @Composable
-fun SnapBackSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Offset) -> Unit) {
+fun SnapBackSample(
+    settings: Settings,
+    onTap: (Offset) -> Unit,
+    onLongPress: (Offset) -> Unit,
+    onLongPressReleased: (Offset) -> Unit,
+) {
     val painter = painterResource(resource = Res.drawable.bird1)
     val zoomState = rememberZoomState(
         contentSize = painter.intrinsicSize,
@@ -29,6 +34,7 @@ fun SnapBackSample(settings: Settings, onTap: (Offset) -> Unit, onLongPress: (Of
                 zoomEnabled = settings.zoomEnabled,
                 onTap = onTap,
                 onLongPress = onLongPress,
+                onLongPressReleased = onLongPressReleased,
             ),
     )
 }

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/DetectZoomableGestures.kt
@@ -43,6 +43,7 @@ internal suspend fun PointerInputScope.detectZoomableGestures(
     onTap: ((position: Offset) -> Unit)? = null,
     onDoubleTap: ((position: Offset) -> Unit)? = null,
     onLongPress: ((position: Offset) -> Unit)? = null,
+    onLongPressReleased: ((position: Offset) -> Unit)? = null,
 ) = awaitEachGesture {
     val firstDown = awaitFirstDown(requireUnconsumed = false)
     if (onTap != null || onDoubleTap != null || onLongPress != null || enableOneFingerZoom()) {
@@ -56,6 +57,7 @@ internal suspend fun PointerInputScope.detectZoomableGestures(
         onTap = onTap,
         onDoubleTap = onDoubleTap,
         onLongPress = onLongPress,
+        onLongPressReleased = onLongPressReleased,
         enableOneFingerZoom = enableOneFingerZoom,
     )
     onGestureEnd()
@@ -69,6 +71,7 @@ private suspend fun AwaitPointerEventScope.detectGesture(
     onTap: ((position: Offset) -> Unit)?,
     onDoubleTap: ((position: Offset) -> Unit)?,
     onLongPress: ((position: Offset) -> Unit)?,
+    onLongPressReleased: ((position: Offset) -> Unit)?,
 ) {
     val startPosition = currentEvent.changes[0].position
     var event = try {
@@ -78,6 +81,8 @@ private suspend fun AwaitPointerEventScope.detectGesture(
     } catch (_: PointerEventTimeoutCancellationException) {
         onLongPress?.invoke(startPosition)
         consumeAllEventsUntilReleased()
+        val endPosition = currentEvent.changes[0].position
+        onLongPressReleased?.invoke(endPosition)
         return
     }
 

--- a/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/net/engawapg/lib/zoomable/Zoomable.kt
@@ -67,6 +67,7 @@ public fun Modifier.zoomable(
         if (zoomEnabled) zoomState.toggleScale(2.5f, position)
     },
     onLongPress: ((position: Offset) -> Unit)? = null,
+    onLongPressReleased: ((position: Offset) -> Unit)? = null,
     mouseWheelZoom: MouseWheelZoom = MouseWheelZoom.EnabledWithCtrlKey,
 ): Modifier = this then ZoomableElement(
     zoomState = zoomState,
@@ -77,6 +78,7 @@ public fun Modifier.zoomable(
     onTap = onTap,
     onDoubleTap = onDoubleTap,
     onLongPress = onLongPress,
+    onLongPressReleased = onLongPressReleased,
     mouseWheelZoom = mouseWheelZoom,
     enableNestedScroll = false,
 )
@@ -99,6 +101,7 @@ public fun Modifier.snapBackZoomable(
     onTap: ((position: Offset) -> Unit)? = null,
     onDoubleTap: (suspend (position: Offset) -> Unit)? = null,
     onLongPress: ((position: Offset) -> Unit)? = null,
+    onLongPressReleased: ((position: Offset) -> Unit)? = null,
 ): Modifier = this then ZoomableElement(
     zoomState = zoomState,
     zoomEnabled = zoomEnabled,
@@ -108,6 +111,7 @@ public fun Modifier.snapBackZoomable(
     onTap = onTap,
     onDoubleTap = onDoubleTap,
     onLongPress = onLongPress,
+    onLongPressReleased = onLongPressReleased,
     mouseWheelZoom = MouseWheelZoom.Disabled,
     enableNestedScroll = false,
 )
@@ -146,6 +150,7 @@ public fun Modifier.zoomableWithScroll(
         if (zoomEnabled) zoomState.toggleScale(2.5f, position)
     },
     onLongPress: ((position: Offset) -> Unit)? = null,
+    onLongPressReleased: ((position: Offset) -> Unit)? = null,
     mouseWheelZoom: MouseWheelZoom = MouseWheelZoom.EnabledWithCtrlKey,
 ): Modifier = this then ZoomableElement(
     zoomState = zoomState,
@@ -156,6 +161,7 @@ public fun Modifier.zoomableWithScroll(
     onTap = onTap,
     onDoubleTap = onDoubleTap,
     onLongPress = onLongPress,
+    onLongPressReleased = onLongPressReleased,
     mouseWheelZoom = mouseWheelZoom,
     enableNestedScroll = true,
 )
@@ -169,6 +175,7 @@ private data class ZoomableElement(
     val onTap: ((position: Offset) -> Unit)?,
     val onDoubleTap: (suspend (position: Offset) -> Unit)?,
     val onLongPress: ((position: Offset) -> Unit)?,
+    val onLongPressReleased: ((position: Offset) -> Unit)? = null,
     val mouseWheelZoom: MouseWheelZoom,
     val enableNestedScroll: Boolean,
 ) : ModifierNodeElement<ZoomableNode>() {
@@ -181,6 +188,7 @@ private data class ZoomableElement(
         onTap,
         onDoubleTap,
         onLongPress,
+        onLongPressReleased,
         mouseWheelZoom,
         enableNestedScroll,
     )
@@ -195,6 +203,7 @@ private data class ZoomableElement(
             onTap,
             onDoubleTap,
             onLongPress,
+            onLongPressReleased,
             mouseWheelZoom,
         )
     }
@@ -223,6 +232,7 @@ private class ZoomableNode(
     var onTap: ((position: Offset) -> Unit)?,
     var onDoubleTap: (suspend (position: Offset) -> Unit)?,
     var onLongPress: ((position: Offset) -> Unit)?,
+    var onLongPressReleased: ((position: Offset) -> Unit)?,
     var mouseWheelZoom: MouseWheelZoom,
     enableNestedScroll: Boolean,
 ) : PointerInputModifierNode, LayoutModifierNode, DelegatingNode() {
@@ -237,6 +247,7 @@ private class ZoomableNode(
         onTap: ((position: Offset) -> Unit)?,
         onDoubleTap: (suspend (position: Offset) -> Unit)?,
         onLongPress: ((position: Offset) -> Unit)?,
+        onLongPressReleased: ((position: Offset) -> Unit)?,
         mouseWheelZoom: MouseWheelZoom,
     ) {
         if (this.zoomState != zoomState) {
@@ -256,6 +267,7 @@ private class ZoomableNode(
         this.onTap = onTap
         this.onDoubleTap = onDoubleTap
         this.onLongPress = onLongPress
+        this.onLongPressReleased = onLongPressReleased
         this.mouseWheelZoom = mouseWheelZoom
     }
 
@@ -325,6 +337,11 @@ private class ZoomableNode(
                 },
                 onLongPress = if (onLongPress != null) {
                     { onLongPress?.invoke(it) }
+                } else {
+                    null
+                },
+                onLongPressReleased = if (onLongPressReleased != null) {
+                    { onLongPressReleased?.invoke(it) }
                 } else {
                     null
                 },

--- a/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/DetectZoomableGesturesTest.kt
+++ b/zoomable/src/commonTest/kotlin/net/engawapg/lib/zoomable/DetectZoomableGesturesTest.kt
@@ -61,6 +61,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         var tap: Int = 0,
         var doubleTap: Int = 0,
         var longPress: Int = 0,
+        var longPressReleased: Int = 0,
     )
 
     private fun ComposeUiTest.pointerInputContentWithDetectZoomableGestures(
@@ -71,6 +72,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         onTap: ((Offset) -> Unit)? = { result.tap++ },
         onDoubleTap: ((Offset) -> Unit)? = { result.doubleTap++ },
         onLongPress: ((Offset) -> Unit)? = { result.longPress++ },
+        onLongPressReleased: ((Offset) -> Unit)? = { result.longPressReleased++ },
     ): SemanticsNodeInteraction {
         val testTag = "target"
         setContent {
@@ -89,6 +91,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                             onTap = onTap,
                             onDoubleTap = onDoubleTap,
                             onLongPress = onLongPress,
+                            onLongPressReleased = onLongPressReleased,
                             enableOneFingerZoom = { enableOneFingerZoom },
                         )
                     }
@@ -135,6 +138,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                                 onTap = { result.tap++ },
                                 onDoubleTap = { result.doubleTap++ },
                                 onLongPress = { result.longPress++ },
+                                onLongPressReleased = { result.longPressReleased++ },
                                 enableOneFingerZoom = { enableOneFingerZoom },
                             )
                         }
@@ -270,6 +274,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         }
 
         assertEquals(0, result.longPress)
+        assertEquals(0, result.longPressReleased)
 
         target.performTouchInput {
             advanceEventTime(500L)
@@ -281,6 +286,8 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         target.performGesture {
             up()
         }
+
+        assertEquals(1, result.longPressReleased)
 
         assertEquals(0, result.tap)
     }
@@ -332,6 +339,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         }
 
         assertEquals(1, result.longPress)
+        assertEquals(1, result.longPressReleased)
         assertEquals(Offset.Zero, result.pan)
     }
 
@@ -383,6 +391,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         }
 
         assertEquals(0, result.longPress)
+        assertEquals(0, result.longPressReleased)
     }
 
     @Test
@@ -483,6 +492,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         assertEquals(Offset.Zero, result.pan)
         assertEquals(1f, result.zoom)
         assertEquals(1, result.longPress)
+        assertEquals(1, result.longPressReleased)
     }
 
     @Test
@@ -498,6 +508,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         }
 
         assertEquals(0, result.longPress)
+        assertEquals(0, result.longPressReleased)
         assertEquals(Offset(50f, 0f), result.pan)
     }
 
@@ -544,6 +555,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
                                 onTap = null,
                                 onDoubleTap = null,
                                 onLongPress = null,
+                                onLongPressReleased = null,
                                 enableOneFingerZoom = { false },
                             )
                         }
@@ -596,6 +608,7 @@ class DetectZoomableGesturesTest : PlatformZoomableTest() {
         assertEquals(Offset.Zero, result.pan)
         assertEquals(1f, result.zoom)
         assertEquals(0, result.longPress, "long press should not be called")
+        assertEquals(0, result.longPressReleased, "long press released should not be called")
         assertEquals(0, result.doubleTap, "double tap should not be called")
         assertEquals(0, result.tap, "tap should not be called")
     }


### PR DESCRIPTION
Adds an optional onLongPressReleased callback to the gesture modifier to support use cases where handling the release of a long press is essential—e.g., temporarily speeding up video playback during a long press. This change also includes test updates.