### PR TITLE
Switch androidx.core:core-ktx to androidx.core:core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ compose-material-icons = { module = "org.jetbrains.compose.material:material-ico
 
 androidx-annotation = "androidx.annotation:annotation:1.10.0"
 androidx-activity = "androidx.activity:activity-compose:1.13.0"
-androidx-core = "androidx.core:core-ktx:1.19.0"
+androidx-core = "androidx.core:core:1.19.0"
 
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- In androidx.core 1.19.0, all Kotlin extensions from `core-ktx` were merged into the `core` artifact, and `core-ktx` is now an empty compatibility shim.
- Switch the `androidx-core` alias in the version catalog to depend on `androidx.core:core:1.19.0` directly.
- No source changes are required. The only API used in this repo (`WindowInsetsControllerCompat` in `samples/shared/src/androidMain/.../Theme.android.kt`) is available from `core`.

## Test plan
- [x] `./gradlew :samples:androidApp:assembleDebug` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)